### PR TITLE
Parallel compilation of rocksdb

### DIFF
--- a/rocksdb-sys/Cargo.toml
+++ b/rocksdb-sys/Cargo.toml
@@ -19,4 +19,4 @@ static = []
 libc = "0.2"
 
 [build-dependencies]
-gcc = "0.3"
+gcc = { version = "0.3", features = ["parallel"] }


### PR DESCRIPTION
gcc-rs just added support for parallel compilation as a feature. The feature pulls in rayon as a dependency and then parallel compiles. Rocksdb is a sufficiently large compilation that this seems worth it. Cuts it down from 220 seconds to around 70 seconds on my machine (2 cores, 4 with hyperthreading).